### PR TITLE
Add support VS2019 IA32 EmulatorPkg Build

### DIFF
--- a/.azurepipelines/platforms/Emulator/Windows-VS2019.yml
+++ b/.azurepipelines/platforms/Emulator/Windows-VS2019.yml
@@ -29,16 +29,26 @@ jobs:
           Build.Arch: "X64"
           Build.Flags: ""
           Build.Target: "RELEASE"
-        # EMULATORPKG_IA32_DEBUG:
-        #   Build.File: "EmulatorPkg/PlatformBuild.py"
-        #   Build.Arch: "IA32"
-        #   Build.Flags: ""
-        #   Build.Target: "DEBUG"
-        # EMULATORPKG_IA32_RELEASE:
-        #   Build.File: "EmulatorPkg/PlatformBuild.py"
-        #   Build.Arch: "IA64"
-        #   Build.Flags: ""
-        #   Build.Target: "RELEASE"
+        EMULATORPKG_X64_NOOPT:
+          Build.File: "EmulatorPkg/PlatformBuild.py"
+          Build.Arch: "X64"
+          Build.Flags: ""
+          Build.Target: "NOOPT"
+        EMULATORPKG_IA32_DEBUG:
+          Build.File: "EmulatorPkg/PlatformBuild.py"
+          Build.Arch: "IA32"
+          Build.Flags: ""
+          Build.Target: "DEBUG"
+        EMULATORPKG_IA32_RELEASE:
+          Build.File: "EmulatorPkg/PlatformBuild.py"
+          Build.Arch: "IA32"
+          Build.Flags: ""
+          Build.Target: "RELEASE"
+        EMULATORPKG_IA32_NOOPT:
+          Build.File: "EmulatorPkg/PlatformBuild.py"
+          Build.Arch: "IA32"
+          Build.Flags: ""
+          Build.Target: "NOOPT"
     workspace:
       clean: all
 

--- a/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
+++ b/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
@@ -13,6 +13,7 @@ import edk2toollib.windows.locate_tools as locate_tools
 from edk2toollib.windows.locate_tools import FindWithVsWhere
 from edk2toolext.environment import shell_environment
 from edk2toolext.environment import version_aggregator
+from edk2toollib.utility_functions import GetHostInfo
 
 
 class WindowsVsToolChain(IUefiBuildPlugin):
@@ -26,13 +27,38 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                             "UCRTVersion", "WindowsLibPath", "WindowsSdkBinPath", "WindowsSdkDir", "WindowsSdkVerBinPath",
                             "WindowsSDKVersion", "VCToolsInstallDir", "Path"]
 
-#
+        #
         # VS2017 - Follow VS2017 where there is potential for many versions of the tools.
         # If a specific version is required then the user must set both env variables:
         # VS150INSTALLPATH:  base install path on system to VC install dir.  Here you will find the VC folder, etc
         # VS150TOOLVER:      version number for the VC compiler tools
         # VS2017_PREFIX:     path to MSVC compiler folder with trailing slash (can be used instead of two vars above)
+        # VS2017_HOST:       set the host architecture to use for host tools, and host libs, etc
         if thebuilder.env.GetValue("TOOL_CHAIN_TAG") == "VS2017":
+
+            # check to see if host is configured
+            # HostType for VS2017 should be (defined in tools_def):
+            # x86   == 32bit Intel
+            # x64   == 64bit Intel
+            # arm   == 32bit Arm
+            # arm64 == 64bit Arm
+            #
+            HostType = shell_environment.GetEnvironment().get_shell_var("VS2017_HOST")
+            if HostType != None:
+                HostType = HostType.lower()
+                self.Logger.info(f"HOST TYPE defined by environment.  Host Type is {HostType}")
+            else:
+                HostInfo = GetHostInfo()
+                if HostInfo.arch == "x86":
+                    if HostInfo.bit == "32":
+                        HostType = "x86"
+                    elif HostInfo.bit == "64":
+                        HostType = "x64"
+                else:
+                    raise NotImplementedError()
+
+            # VS2017_HOST options are not exactly the same as QueryVcVariables. This translates.
+            VC_HOST_ARCH_TRANSLATOR = {"x86": "x86", "x64": "AMD64", "arm": "i don't know", "arm64": "i don't know"}
 
             # check to see if full path already configured
             if shell_environment.GetEnvironment().get_shell_var("VS2017_PREFIX") != None:
@@ -58,16 +84,14 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                                       "Tools", "MSVC", vc_ver)
                 prefix = prefix + os.path.sep
                 shell_environment.GetEnvironment().set_shell_var("VS2017_PREFIX", prefix)
+                shell_environment.GetEnvironment().set_shell_var("VS2017_HOST", HostType)
 
                 shell_env = shell_environment.GetEnvironment()
                 # Use the tools lib to determine the correct values for the vars that interest us.
                 vs_vars = locate_tools.QueryVcVariables(
-                    interesting_keys, "amd64", vs_version="vs2017")
+                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="vs2017")
                 for (k, v) in vs_vars.items():
-                    if k.upper() == "PATH":
-                        shell_env.insert_path(v)
-                    else:
-                        shell_env.set_shell_var(k, v)
+                    shell_env.set_shell_var(k, v)
 
             # now confirm it exists
             if not os.path.exists(shell_environment.GetEnvironment().get_shell_var("VS2017_PREFIX")):
@@ -80,7 +104,32 @@ class WindowsVsToolChain(IUefiBuildPlugin):
         # VS160INSTALLPATH:  base install path on system to VC install dir.  Here you will find the VC folder, etc
         # VS160TOOLVER:      version number for the VC compiler tools
         # VS2019_PREFIX:     path to MSVC compiler folder with trailing slash (can be used instead of two vars above)
+        # VS2017_HOST:       set the host architecture to use for host tools, and host libs, etc
         elif thebuilder.env.GetValue("TOOL_CHAIN_TAG") == "VS2019":
+
+            # check to see if host is configured
+            # HostType for VS2019 should be (defined in tools_def):
+            # x86   == 32bit Intel
+            # x64   == 64bit Intel
+            # arm   == 32bit Arm
+            # arm64 == 64bit Arm
+            #
+            HostType = shell_environment.GetEnvironment().get_shell_var("VS2019_HOST")
+            if HostType != None:
+                HostType = HostType.lower()
+                self.Logger.info(f"HOST TYPE defined by environment.  Host Type is {HostType}")
+            else:
+                HostInfo = GetHostInfo()
+                if HostInfo.arch == "x86":
+                    if HostInfo.bit == "32":
+                        HostType = "x86"
+                    elif HostInfo.bit == "64":
+                        HostType = "x64"
+                else:
+                    raise NotImplementedError()
+
+            # VS2019_HOST options are not exactly the same as QueryVcVariables. This translates.
+            VC_HOST_ARCH_TRANSLATOR = {"x86": "x86", "x64": "AMD64", "arm": "i don't know", "arm64": "i don't know"}
 
             # check to see if full path already configured
             if shell_environment.GetEnvironment().get_shell_var("VS2019_PREFIX") != None:
@@ -106,16 +155,14 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                                       "Tools", "MSVC", vc_ver)
                 prefix = prefix + os.path.sep
                 shell_environment.GetEnvironment().set_shell_var("VS2019_PREFIX", prefix)
+                shell_environment.GetEnvironment().set_shell_var("VS2019_HOST", HostType)
 
                 shell_env = shell_environment.GetEnvironment()
                 # Use the tools lib to determine the correct values for the vars that interest us.
                 vs_vars = locate_tools.QueryVcVariables(
-                    interesting_keys, "amd64", vs_version="vs2019")
+                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="vs2019")
                 for (k, v) in vs_vars.items():
-                    if k.upper() == "PATH":
-                        shell_env.insert_path(v)
-                    else:
-                        shell_env.set_shell_var(k, v)
+                    shell_env.set_shell_var(k, v)
 
             # now confirm it exists
             if not os.path.exists(shell_environment.GetEnvironment().get_shell_var("VS2019_PREFIX")):

--- a/EmulatorPkg/PlatformBuild.py
+++ b/EmulatorPkg/PlatformBuild.py
@@ -139,8 +139,19 @@ class PlatformBuilder( UefiBuilder, BuildSettingsManager):
         logging.debug("PlatformBuilder SetPlatformEnv")
         self.env.SetValue("PRODUCT_NAME", "EmulatorPkg", "Platform Hardcoded")
         self.env.SetValue("TOOL_CHAIN_TAG", "VS2019", "Default Toolchain")
+
+        # Add support for using the correct Platform Headers, tools, and Libs based on emulator architecture
+        # requested to be built.
+        if self.env.GetValue("TOOL_CHAIN_TAG") == "VS2019" or self.env.GetValue("TOOL_CHAIN_TAG") == "VS2017":
+            key = self.env.GetValue("TOOL_CHAIN_TAG") + "_HOST"
+            if self.env.GetValue("TARGET_ARCH") == "IA32":
+                shell_environment.ShellEnvironment().set_shell_var(key, "x86")
+            elif self.env.GetValue("TARGET_ARCH") == "X64":
+                shell_environment.ShellEnvironment().set_shell_var(key, "x64")
+
         if GetHostInfo().os.upper() == "WINDOWS":
             self.env.SetValue("BLD_*_WIN_HOST_BUILD", "TRUE", "Trigger Windows host build")
+
         self.env.SetValue("MAKE_STARTUP_NSH", "FALSE", "Default to false")
         return 0
 


### PR DESCRIPTION
Add support for controlling the HOST arch for VS2017 and VS2019 compilers.
Add support for using that same HOST arch for configuring the windows platform headers, libs, and tools.
Enable the CI